### PR TITLE
Remove declared proxy system properties

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,3 @@
-systemProp.https.proxyHost=127.0.0.1
-systemProp.https.proxyPort=3067
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 android.useAndroidX=true


### PR DESCRIPTION
This should not be shared, you can place it in your `~/.gradle/gradle.properties` file if necessary.