### PR TITLE
Fix: Clean up test queues after subscription update

### DIFF
--- a/lib/app/modules/server_manager.dart
+++ b/lib/app/modules/server_manager.dart
@@ -1611,6 +1611,11 @@ class ServerManager {
         }
         exist.traffic = item.traffic;
         exist.servers = item.servers;
+        
+        // Clean up test queues for updated server list
+        Set<String> validTags = item.servers.map((s) => s.tag).toSet();
+        exist.testLatency.removeWhere((tag) => !validTags.contains(tag));
+        exist.testLatencyIndepends.removeWhere((tag) => !validTags.contains(tag));
         break;
       }
     }


### PR DESCRIPTION
## Problem
After updating subscription links, the test latency queues (testLatency/testLatencyIndepends) still contain tags of servers that no longer exist, causing testing issues.

## Root Cause
In loadFrom() function, when replacing existing server list with new one:
- Server list is updated correctly
- Old latency values are preserved for matching servers
- But test queues are not cleaned up, still containing removed server tags

## Solution
After updating server list in loadFrom(), clean up test queues to remove any tags of servers that no longer exist in the updated list.

## Impact
- Fixes latency testing issues after subscription update
- Ensures test queues only contain valid server tags
- Maintains backward compatibility