### PR TITLE
feat: support encrypted subscription decryption (AES-128-CBC)

### DIFF
--- a/PR_SUBSCRIPTION_DECRYPT.md
+++ b/PR_SUBSCRIPTION_DECRYPT.md
@@ -1,0 +1,63 @@
+# [Feature] Support encrypted subscription decryption
+
+Closes #1346 (https://github.com/KaringX/karing/issues/1346)
+
+## Summary
+
+- When the subscription response has header `subscription-encryption: true`, the content is AES-128-CBC encrypted. This PR adds decryption support so users can enter the subscription password (site login password) to decrypt.
+
+## Changes
+
+1. **`lib/app/utils/subscription_decrypt.dart`** (new)
+   - `isSubscriptionEncrypted(headerValue)` – checks if response is encrypted
+   - `tryDecryptSubscription(password, base64Data)` – AES-128-CBC decrypt (key = MD5(password) as 32-char hex → 16 bytes; IV = first 16 bytes of base64 decoded body; cipher = rest)
+   - `decryptSubscriptionResponse(encHeader, body, password)` – helper that decrypts if encrypted or returns body unchanged; throws `SubscriptionEncryptedException` when password is missing or wrong
+   - Matches the algorithm described in the issue (same as flclash / v2rayN)
+
+2. **`lib/app/modules/server_manager.dart`**
+   - `loadFrom(..., subscriptionPassword)` – optional parameter passed through to `AutoConfUtils.tryConvert`
+   - `addRemoteConfig(..., subscriptionPassword)` – optional parameter; stores password per groupid for later updates; catches `SubscriptionEncryptedException` and returns a user-facing error
+   - Subscription passwords persisted in `subscription_passwords.json` (same directory as subscribe config); loaded on init, used for `updateSubscription` and reload
+   - `getSubscriptionPassword(groupid)` / `setSubscriptionPassword(groupid, password)` for edit screen
+
+3. **`lib/screens/add_profile_by_link_or_content_screen.dart`**
+   - Optional "Subscription password (for encrypted)" field; value passed to `addRemoteConfig(subscriptionPassword: ...)`
+
+4. **`lib/screens/my_profiles_edit_screen.dart`**
+   - Optional "Subscription password (for encrypted)" field; value read/saved via `ServerManager.getSubscriptionPassword` / `setSubscriptionPassword`
+
+5. **`pubspec.yaml`**
+   - Added dependency `encrypt: 5.0.3` for AES-128-CBC.
+
+## Integration required in `AutoConfUtils.tryConvert`
+
+`tryConvert` is currently called with 7 arguments. This PR adds an 8th argument `subscriptionPassword` (String?). Please update the signature and implementation as follows:
+
+- When fetching subscription by URL, after receiving the HTTP response:
+  - Read header `subscription-encryption` (case-insensitive).
+  - If `isSubscriptionEncrypted(headerValue)` is true:
+    - Use `SubscriptionDecrypt.decryptSubscriptionResponse(response.headers['subscription-encryption'], response.bodyBytes, subscriptionPassword)` to get the decrypted body (or let it throw `SubscriptionEncryptedException` if password is missing/wrong).
+    - Use the decrypted bytes as the subscription content for parsing.
+  - Otherwise use the response body as usual.
+
+Example (pseudo):
+
+```dart
+// after getting response with headers and body
+try {
+  body = decryptSubscriptionResponse(
+    response.headers.value('subscription-encryption'),
+    response.bodyBytes,
+    subscriptionPassword,
+  );
+} on SubscriptionEncryptedException catch (e) {
+  rethrow; // so addRemoteConfig can catch and show message
+}
+// then parse body as before
+```
+
+## Testing
+
+- Add a subscription with an encrypted subscription URL; enter the correct password → should succeed.
+- Add without password or with wrong password → should show error asking for password or "Incorrect subscription password".
+- Edit profile: set/change subscription password and save → password is stored and used on next reload/update.

--- a/lib/app/utils/subscription_decrypt.dart
+++ b/lib/app/utils/subscription_decrypt.dart
@@ -1,0 +1,100 @@
+// Support for encrypted subscription (AES-128-CBC).
+// See: https://github.com/KaringX/karing/issues/1346
+// When response header subscription-encryption = true, decrypt with user password.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:encrypt/encrypt.dart';
+
+/// HTTP response header for subscription encryption (same as v2rayN / flclash)
+const String subscriptionEncryptionHeader = 'subscription-encryption';
+const String aesEncryptionValue = 'true';
+
+/// Check if response headers indicate AES-encrypted subscription
+bool isSubscriptionEncrypted(String? headerValue) {
+  if (headerValue == null || headerValue.isEmpty) return false;
+  return headerValue.trim().toLowerCase() == aesEncryptionValue;
+}
+
+/// Try to decrypt subscription content (AES-128-CBC).
+/// Key: MD5(password) as 32-char hex -> 16 bytes
+/// IV: first 16 bytes of base64 decoded data
+/// Cipher: bytes 16.. of base64 decoded data
+Uint8List? tryDecryptSubscription(String password, String base64Data) {
+  if (base64Data.isEmpty || password.isEmpty) return null;
+
+  final passHash = md5.convert(utf8.encode(password)).toString();
+  if (passHash.length != 32) return null;
+
+  Uint8List keyBytes;
+  try {
+    keyBytes = Uint8List.fromList(
+      List.generate(
+        16,
+        (i) => int.parse(passHash.substring(i * 2, i * 2 + 2), radix: 16),
+      ),
+    );
+  } catch (_) {
+    return null;
+  }
+
+  Uint8List raw;
+  try {
+    final normalized =
+        base64Data.trim().replaceAll('\n', '').replaceAll('\r', '');
+    raw = base64Decode(normalized);
+  } catch (_) {
+    return null;
+  }
+
+  if (raw.length <= 16) return null;
+
+  final iv = IV(raw.sublist(0, 16));
+  final cipher = Encrypted(Uint8List.fromList(raw.sublist(16)));
+  final key = Key(keyBytes);
+
+  try {
+    final encrypter =
+        Encrypter(AES(key, mode: AESMode.cbc, padding: 'PKCS7'));
+    final decrypted = encrypter.decrypt(cipher, iv: iv);
+    final bytes = Uint8List.fromList(utf8.encode(decrypted));
+    return bytes.isNotEmpty ? bytes : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Exception when subscription is encrypted and password is required or wrong.
+class SubscriptionEncryptedException implements Exception {
+  const SubscriptionEncryptedException({this.passwordWrong = false});
+
+  /// True when password was provided but decryption failed (wrong password)
+  final bool passwordWrong;
+
+  @override
+  String toString() => passwordWrong
+      ? 'SubscriptionEncryptedException(passwordWrong: true)'
+      : 'SubscriptionEncryptedException(passwordRequired)';
+}
+
+/// Decrypt subscription response body if header indicates encryption.
+/// Returns [body] unchanged when not encrypted; otherwise decrypts with [password].
+/// Throws [SubscriptionEncryptedException] when encrypted and password missing or wrong.
+Uint8List decryptSubscriptionResponse(
+  String? encHeader,
+  Uint8List body,
+  String? password,
+) {
+  if (!isSubscriptionEncrypted(encHeader)) return body;
+  if (password == null || password.isEmpty) {
+    throw const SubscriptionEncryptedException(passwordWrong: false);
+  }
+  final base64Str = utf8.decode(body);
+  final decrypted = tryDecryptSubscription(password, base64Str);
+  if (decrypted == null) {
+    throw const SubscriptionEncryptedException(passwordWrong: true);
+  }
+  return decrypted;
+}

--- a/lib/screens/add_profile_by_link_or_content_screen.dart
+++ b/lib/screens/add_profile_by_link_or_content_screen.dart
@@ -53,6 +53,7 @@ class _AddProfileByLinkOrContentScreenState
     with AfterLayoutMixin {
   final _textControllerLink = TextEditingController();
   final _textControllerRemark = TextEditingController();
+  final _textControllerSubscriptionPassword = TextEditingController();
   bool _loading = false;
   bool _keepDiversionRules = false;
   String _compatible = "";
@@ -94,6 +95,7 @@ class _AddProfileByLinkOrContentScreenState
     --AddProfileByLinkOrContentScreen.pushed;
     _textControllerLink.dispose();
     _textControllerRemark.dispose();
+    _textControllerSubscriptionPassword.dispose();
     super.dispose();
   }
 
@@ -225,6 +227,9 @@ class _AddProfileByLinkOrContentScreenState
       website: _website,
       ispId: widget.ispId,
       ispUser: widget.ispUser,
+      subscriptionPassword: _textControllerSubscriptionPassword.text.trim().isEmpty
+          ? null
+          : _textControllerSubscriptionPassword.text.trim(),
     );
 
     if (!mounted) {
@@ -382,12 +387,23 @@ class _AddProfileByLinkOrContentScreenState
                         ),
                         const SizedBox(height: 20),
                         TextFieldEx(
-                          textInputAction: TextInputAction.done,
+                          textInputAction: TextInputAction.next,
                           controller: _textControllerRemark,
                           decoration: InputDecoration(
                             labelText: tcontext.meta.remark,
                             hintText: tcontext.meta.required,
                             prefixIcon: const Icon(Icons.edit_note_outlined),
+                          ),
+                        ),
+                        const SizedBox(height: 20),
+                        TextFieldEx(
+                          textInputAction: TextInputAction.done,
+                          controller: _textControllerSubscriptionPassword,
+                          obscureText: true,
+                          decoration: const InputDecoration(
+                            labelText: 'Subscription password (for encrypted)',
+                            hintText: 'Optional',
+                            prefixIcon: Icon(Icons.lock_outline),
                           ),
                         ),
                         const SizedBox(height: 20),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -105,6 +105,7 @@ dependencies:
   tuple: 2.0.2
   crypto: 3.0.7
   cryptography: 2.9.0
+  encrypt: 5.0.3
   open_dir: 0.0.2+1
   in_app_review: 2.0.11
   path: 1.9.1 #flutter_test


### PR DESCRIPTION
- Add subscription_decrypt.dart: isSubscriptionEncrypted, tryDecryptSubscription, decryptSubscriptionResponse, SubscriptionEncryptedException (ref #1346)
- server_manager: subscriptionPassword param for addRemoteConfig/loadFrom, persist passwords for auto-update, pass to tryConvert (upstream to add 8th arg)
- Add/edit profile screens: optional subscription password field
- pubspec: add encrypt 5.0.3

Closes #1346