### PR TITLE
fix(RU Preset): typo in WhatsApp package name

### DIFF
--- a/assets/datas/preset/ru.json
+++ b/assets/datas/preset/ru.json
@@ -134,7 +134,7 @@
                 "acl:Whatsapp"
             ],
             "package": [
-                "com.whatapp"
+                "com.whatsapp"
             ],
             "processName": [
                 "WhatsApp.exe",


### PR DESCRIPTION
Valid WhatsApp package name is `com.whatsapp`, not `com.whatapp`.
Ref: [https://play.google.com/store/apps/details?id=_**com.whatsapp**_](https://play.google.com/store/apps/details?id=com.whatsapp).