### PR TITLE
Hotfix checking domain on Detect Screen

### DIFF
--- a/lib/screens/diversion_rule_detect_screen.dart
+++ b/lib/screens/diversion_rule_detect_screen.dart
@@ -370,7 +370,7 @@ class _DiversionRuleDetectScreenState
     if (!setting.novice && setting.dns.enableInboundDomainResolve) {
       ReturnResult<String> resultDns = await ClashApi.dnsQueryWithDefaultRouter(
         SettingManager.getConfig().proxy.controlPort,
-        _domain,
+        _encoded.value,
         setting.ipStrategy.name,
       );
       if (resultDns.error == null) {
@@ -387,7 +387,7 @@ class _DiversionRuleDetectScreenState
 
     ReturnResult<String> outboundResult = await ClashApi.outboundQuery(
       setting.proxy.controlPort,
-      _domain,
+      _encoded.value,
       ip,
     );
 


### PR DESCRIPTION
Fixed a bug where entering a full URL (which is allowed) caused subsequent checks to run against the raw link instead of the extracted domain.

<img width="350" height="" alt="image" src="https://github.com/user-attachments/assets/0d551511-2cce-497f-b163-6cee85677db9" />

<img width="350" height="" alt="image" src="https://github.com/user-attachments/assets/0778996c-77b8-44e8-b758-ca2cbb34b7ec" />
