### PR TITLE
feat(linux): detect desktop environment for GTK window configuration

### DIFF
--- a/linux/main.cc
+++ b/linux/main.cc
@@ -1,6 +1,7 @@
 #include "my_application.h"
 
 int main(int argc, char** argv) {
+  my_application_configure_windowing();
   g_autoptr(MyApplication) app = my_application_new();
   return g_application_run(G_APPLICATION(app), argc, argv);
 }

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -1,9 +1,6 @@
 #include "my_application.h"
 
 #include <flutter_linux/flutter_linux.h>
-#ifdef GDK_WINDOWING_X11
-#include <gdk/gdkx.h>
-#endif
 
 #include "flutter/generated_plugin_registrant.h"
 
@@ -15,6 +12,32 @@ struct _MyApplication {
 G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 //#define ICON_PATH "./karing.png"
 
+static gboolean desktop_uses_gtk_header_bar() {
+  const gchar* desktops = g_getenv("XDG_CURRENT_DESKTOP");
+  if (desktops == nullptr || *desktops == '\0') {
+    desktops = g_getenv("DESKTOP_SESSION");
+  }
+
+  if (desktops == nullptr) {
+    return FALSE;
+  }
+
+  g_auto(GStrv) values = g_strsplit(desktops, ":", -1);
+  for (gchar** value = values; *value != nullptr; value++) {
+    if (g_ascii_strcasecmp(*value, "unity") == 0 ||
+        g_ascii_strcasecmp(*value, "gnome") == 0 ||
+        g_ascii_strncasecmp(*value, "gnome-", 6) == 0) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+void my_application_configure_windowing() {
+  g_setenv("GTK_CSD", desktop_uses_gtk_header_bar() ? "1" : "0", TRUE);
+}
+
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
@@ -22,24 +45,7 @@ static void my_application_activate(GApplication* application) {
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
   // gtk_window_set_icon_from_file(window, ICON_PATH, NULL);
 
-  // Use a header bar when running in GNOME as this is the common style used
-  // by applications and is the setup most users will be using (e.g. Ubuntu
-  // desktop).
-  // If running on X and not using GNOME then just use a traditional title bar
-  // in case the window manager does more exotic layout, e.g. tiling.
-  // If running on Wayland assume the header bar will work (may need changing
-  // if future cases occur).
-  gboolean use_header_bar = TRUE;
-#ifdef GDK_WINDOWING_X11
-  GdkScreen* screen = gtk_window_get_screen(window);
-  if (GDK_IS_X11_SCREEN(screen)) {
-    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
-    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
-      use_header_bar = FALSE;
-    }
-  }
-#endif
-  if (use_header_bar) {
+  if (desktop_uses_gtk_header_bar()) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
     gtk_header_bar_set_title(header_bar, "Karing");

--- a/linux/my_application.h
+++ b/linux/my_application.h
@@ -6,6 +6,8 @@
 G_DECLARE_FINAL_TYPE(MyApplication, my_application, MY, APPLICATION,
                      GtkApplication)
 
+void my_application_configure_windowing();
+
 /**
  * my_application_new:
  *


### PR DESCRIPTION
Add centralized windowing setup before application startup and derive GTK header bar behavior from desktop session variables, removing display-server-specific X11 detection. GNOME and Unity use GTK client-side decorations, while KDE Plasma, Xfce, Cinnamon, and other environments receive the window manager system framework regardless of X11 or Wayland.

Before:
<img width="414" height="803" alt="изображение" src="https://github.com/user-attachments/assets/da9b30f2-5e0c-49ee-9a59-37dbf87f7407" />

After:
<img width="412" height="781" alt="изображение" src="https://github.com/user-attachments/assets/0f50ff8f-b477-45fd-8fb0-e7b1de743c63" />
