### PR TITLE
fix(macos): stop polling VPNService.getStarted() every second on home screen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -648,7 +648,11 @@ class _HomeScreenState extends LasyRenderingState<HomeScreen>
     if (AppLifecycleStateNofity.isPaused()) {
       return;
     }
-    bool started = await VPNService.getStarted();
+    // Use the state tracked by _onStateChanged instead of querying the
+    // platform plugin: on macOS every VPNService.getStarted() call goes
+    // through loadAllFromPreferences and creates NETunnelProviderSession
+    // objects, adding per-second XPC round-trips to nesessionmanager.
+    bool started = _state == FlutterVpnServiceState.connected;
     if (!started) {
       String now = _currentServerForUrltest.now;
       int delay = _currentServerForUrltest.history.delay;
@@ -666,7 +670,7 @@ class _HomeScreenState extends LasyRenderingState<HomeScreen>
     _timerCurrentUrltest ??= Timer.periodic(const Duration(seconds: 1), (
       timer,
     ) async {
-      bool started = await VPNService.getStarted();
+      bool started = _state == FlutterVpnServiceState.connected;
       if (!started) {
         if (_currentServerForUrltest.now.isNotEmpty ||
             _currentServerForUrltest.history.delay != 0) {


### PR DESCRIPTION
Part of #1873.

On macOS every getStarted() call goes through loadAllFromPreferences and creates NE session objects, so the 1s urltest ticker adds constant churn on nesessionmanager. The state is already delivered to _onStateChanged, so just use the cached value.

Doesn't fix the session leak itself (that's in the vpn-service plugin, details in the issue), but removes the biggest steady source of it in the app.