### PR TITLE
fix(linux): render country flag emojis without affecting text fonts

### DIFF
--- a/lib/screens/diversion_rule_detect_screen.dart
+++ b/lib/screens/diversion_rule_detect_screen.dart
@@ -14,6 +14,7 @@ import 'package:karing/i18n/strings.g.dart';
 import 'package:karing/screens/dialog_utils.dart';
 import 'package:karing/screens/theme_config.dart';
 import 'package:karing/screens/widgets/framework.dart';
+import 'package:karing/screens/widgets/text.dart';
 import 'package:karing/screens/widgets/text_field.dart';
 import 'package:tuple/tuple.dart';
 
@@ -452,7 +453,7 @@ class _DiversionRuleDetectScreenState
   Widget _buildWithValue(BuildContext context, String value, Widget? child) {
     return SizedBox(
       width: 200,
-      child: Text(
+      child: EmojiText(
         value,
         style: TextStyle(fontSize: ThemeConfig.kFontSizeListSubItem),
       ),
@@ -466,7 +467,7 @@ class _DiversionRuleDetectScreenState
   ) {
     return SizedBox(
       width: 200,
-      child: Text(
+      child: EmojiText(
         value,
         style: TextStyle(
           fontSize: ThemeConfig.kFontSizeListSubItem,

--- a/lib/screens/group_helper.dart
+++ b/lib/screens/group_helper.dart
@@ -1758,7 +1758,6 @@ class GroupHelper {
             text: chainProxy,
             textWidthPercent: 0.7,
             textStyle: TextStyle(
-              fontFamily: Platform.isWindows ? 'Emoji' : null,
               color: invalidOutbounds.isNotEmpty ? Colors.red : null,
             ),
             onPush: () async {

--- a/lib/screens/group_item_widgets.dart
+++ b/lib/screens/group_item_widgets.dart
@@ -1,7 +1,5 @@
 // ignore_for_file: constant_identifier_names
 
-import 'dart:io';
-
 import 'package:board_datetime_picker/board_datetime_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:karing/app/utils/accessibility_utils.dart';
@@ -10,6 +8,7 @@ import 'package:karing/screens/dialog_utils.dart';
 import 'package:karing/screens/group_item_options.dart';
 import 'package:karing/screens/theme_define.dart';
 import 'package:karing/screens/widgets/sheet.dart';
+import 'package:karing/screens/widgets/text.dart';
 import 'package:karing/screens/widgets/text_field.dart';
 
 class GroupItemText extends StatelessWidget {
@@ -54,7 +53,7 @@ class GroupItemText extends StatelessWidget {
             flex: ((options.textWidthPercent) * 10).toInt(),
             child: Align(
               alignment: AlignmentDirectional.centerEnd,
-              child: Text(
+              child: EmojiText(
                 options.text ?? "",
                 maxLines: 3,
                 overflow: TextOverflow.ellipsis,
@@ -590,13 +589,12 @@ class GroupItemStringPicker extends StatelessWidget {
         }
         widgets.add(
           ListTile(
-            title: Text(
+            title: EmojiText(
               key.item2,
               style: TextStyle(
                 color: options.selected == key.item1
                     ? ThemeDefine.kColorBlue
                     : null,
-                fontFamily: Platform.isWindows ? 'Emoji' : null,
               ),
             ),
             onTap: () async {
@@ -611,11 +609,10 @@ class GroupItemStringPicker extends StatelessWidget {
       for (var key in options.strings!) {
         widgets.add(
           ListTile(
-            title: Text(
+            title: EmojiText(
               key ?? "",
               style: TextStyle(
                 color: options.selected == key ? ThemeDefine.kColorBlue : null,
-                fontFamily: Platform.isWindows ? 'Emoji' : null,
               ),
             ),
             onTap: () async {
@@ -662,7 +659,7 @@ class GroupItemStringPicker extends StatelessWidget {
             flex: ((1 - options.textWidthPercent) * 10).toInt(),
             child: Align(
               alignment: AlignmentDirectional.centerStart,
-              child: Text(
+              child: EmojiText(
                 options.name,
                 maxLines: 3,
                 overflow: TextOverflow.ellipsis,
@@ -673,13 +670,10 @@ class GroupItemStringPicker extends StatelessWidget {
             flex: (options.textWidthPercent * 10).toInt(),
             child: Align(
               alignment: AlignmentDirectional.centerEnd,
-              child: Text(
+              child: EmojiText(
                 selectedText,
                 maxLines: 3,
                 overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontFamily: Platform.isWindows ? 'Emoji' : null,
-                ),
               ),
             ),
           ),

--- a/lib/screens/home_screen_widgets.dart
+++ b/lib/screens/home_screen_widgets.dart
@@ -313,15 +313,13 @@ abstract class TextCard1State<T extends TextCard1> extends State<T> {
                     return Row(
                       mainAxisAlignment: MainAxisAlignment.start,
                       children: [
-                        Text(
+                        EmojiText(
                           value,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.bodyMedium?.toLight
-                              .adjustSize(1)
-                              .copyWith(
-                                fontFamily: Platform.isWindows ? 'Emoji' : null,
-                              ),
+                          style: theme.textTheme.bodyMedium?.toLight.adjustSize(
+                            1,
+                          ),
                         ),
                       ],
                     );
@@ -1799,15 +1797,12 @@ class _ServerSelectCardState extends State<ServerSelectCard> {
                               alignment: Alignment.center,
                               width: width,
                               height: 60,
-                              child: Text(
+                              child: EmojiText(
                                 text,
                                 style: TextStyle(
                                   fontWeight:
                                       ThemeConfig.kFontWeightListSubItem,
                                   fontSize: ThemeConfig.kFontSizeListSubItem,
-                                  fontFamily: Platform.isWindows
-                                      ? 'Emoji'
-                                      : null,
                                 ),
                               ),
                             ),

--- a/lib/screens/list_add_screen.dart
+++ b/lib/screens/list_add_screen.dart
@@ -6,6 +6,7 @@ import 'package:karing/screens/dialog_utils.dart';
 import 'package:karing/screens/theme_config.dart';
 import 'package:karing/screens/theme_define.dart';
 import 'package:karing/screens/widgets/framework.dart';
+import 'package:karing/screens/widgets/text.dart';
 
 class ListAddScreen extends LasyRenderingStatefulWidget {
   static RouteSettings routSettings(String viewTag) {
@@ -143,7 +144,7 @@ class _ListAddScreenState extends LasyRenderingState<ListAddScreen> {
                         children: [
                           SizedBox(
                             width: centerWidth,
-                            child: Text(
+                            child: EmojiText(
                               current,
                               overflow: TextOverflow.ellipsis,
                               style: TextStyle(

--- a/lib/screens/my_profiles_screen.dart
+++ b/lib/screens/my_profiles_screen.dart
@@ -42,6 +42,7 @@ import 'package:karing/screens/theme_define.dart';
 import 'package:karing/screens/themes.dart';
 import 'package:karing/screens/widgets/framework.dart';
 import 'package:karing/screens/widgets/sheet.dart';
+import 'package:karing/screens/widgets/text.dart';
 import 'package:karing/screens/widgets/text_field.dart';
 import 'package:path/path.dart' as path;
 import 'package:provider/provider.dart';
@@ -341,7 +342,7 @@ class MyProfilesScreenState extends LasyRenderingState<MyProfilesScreen> {
                       (provider != null ? 16 : 0),
                   child: Tooltip(
                     message: "${item.remark}[${item.servers.length}]",
-                    child: Text(
+                    child: EmojiText(
                       "${item.remark}[${item.servers.length}]",
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(
@@ -828,13 +829,12 @@ class MyProfilesScreenState extends LasyRenderingState<MyProfilesScreen> {
                           width: server.attach.isEmpty
                               ? centerWidth
                               : centerWidth - 30,
-                          child: Text(
+                          child: EmojiText(
                             server.tag,
                             overflow: TextOverflow.ellipsis,
                             maxLines: 3,
                             style: TextStyle(
                               fontSize: ThemeConfig.kFontSizeListSubItem,
-                              fontFamily: Platform.isWindows ? 'Emoji' : null,
                             ),
                           ),
                         ),

--- a/lib/screens/net_check_screen.dart
+++ b/lib/screens/net_check_screen.dart
@@ -21,6 +21,7 @@ import 'package:karing/screens/dialog_utils.dart';
 import 'package:karing/screens/listview_multi_parts_builder.dart';
 import 'package:karing/screens/theme_config.dart';
 import 'package:karing/screens/widgets/framework.dart';
+import 'package:karing/screens/widgets/text.dart';
 import 'package:karing/screens/widgets/text_field.dart';
 import 'package:tuple/tuple.dart';
 
@@ -1030,7 +1031,7 @@ class _NetCheckScreenState extends LasyRenderingState<NetCheckScreen> {
                 const SizedBox(width: 5),
                 SizedBox(
                   width: textWidth,
-                  child: Text(
+                  child: EmojiText(
                     result.error == null ? result.data! : result.error!.message,
                     style: TextStyle(
                       fontSize: ThemeConfig.kFontSizeListSubItem,

--- a/lib/screens/net_connections_screen.dart
+++ b/lib/screens/net_connections_screen.dart
@@ -32,6 +32,7 @@ import 'package:karing/screens/theme_config.dart';
 import 'package:karing/screens/theme_define.dart';
 import 'package:karing/screens/widgets/framework.dart';
 import 'package:karing/screens/widgets/sheet.dart';
+import 'package:karing/screens/widgets/text.dart';
 
 enum ConnectionsSortType { none, downloadSpeed, uploadSpeed, download, upload }
 
@@ -1000,7 +1001,7 @@ class _NetConnectionsScreenState
                           children: [
                             SizedBox(
                               width: centerWidth,
-                              child: Text(
+                              child: EmojiText(
                                 current.showChain,
                                 overflow: TextOverflow.ellipsis,
                                 style: const TextStyle(fontSize: 12),
@@ -1097,7 +1098,7 @@ class _NetConnectionsScreenState
                         ),
                       ),
                       const SizedBox(width: 5),
-                      Text(
+                      EmojiText(
                         current.outbound,
                         style: const TextStyle(fontSize: 12),
                       ),

--- a/lib/screens/server_select_screen.dart
+++ b/lib/screens/server_select_screen.dart
@@ -28,6 +28,7 @@ import 'package:karing/screens/theme_define.dart';
 import 'package:karing/screens/themes.dart';
 import 'package:karing/screens/widgets/framework.dart';
 import 'package:karing/screens/widgets/sheet.dart';
+import 'package:karing/screens/widgets/text.dart';
 import 'package:karing/screens/widgets/text_field.dart';
 import 'package:provider/provider.dart';
 import 'package:tuple/tuple.dart';
@@ -1291,13 +1292,12 @@ class _ServerSelectScreenState extends LasyRenderingState<ServerSelectScreen> {
                         ),
                         SizedBox(
                           width: tagWidth,
-                          child: Text(
+                          child: EmojiText(
                             tag,
                             overflow: TextOverflow.ellipsis,
                             maxLines: 3,
                             style: TextStyle(
                               fontSize: ThemeConfig.kFontSizeListSubItem,
-                              fontFamily: Platform.isWindows ? 'Emoji' : null,
                               color: singleSelectCurrentInvalid
                                   ? Colors.red
                                   : null,

--- a/lib/screens/widgets/enum.dart
+++ b/lib/screens/widgets/enum.dart
@@ -38,7 +38,7 @@ extension KeyboardModifierExt on KeyboardModifier {
 }
 
 enum FontFamily {
-  twEmoji("Twemoji"),
+  emoji("Emoji"),
   jetBrainsMono("JetBrainsMono"),
   icon("Icons");
 

--- a/lib/screens/widgets/text.dart
+++ b/lib/screens/widgets/text.dart
@@ -1,7 +1,7 @@
 import 'enum.dart';
 import 'color.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:emoji_regex/emoji_regex.dart';
 
 class TooltipText extends StatelessWidget {
   final Text text;
@@ -43,9 +43,18 @@ class EmojiText extends StatelessWidget {
     this.style,
   });
 
-  List<TextSpan> _buildTextSpans(String emojis) {
+  List<TextSpan> _buildTextSpans(
+    TextStyle effectiveStyle,
+    bool useBundledFlagFont,
+  ) {
+    if (!useBundledFlagFont) {
+      return [TextSpan(text: text, style: effectiveStyle)];
+    }
     final List<TextSpan> spans = [];
-    final matches = emojiRegex().allMatches(text);
+    final matches = RegExp(
+      r'[\u{1F1E6}-\u{1F1FF}]{2}',
+      unicode: true,
+    ).allMatches(text);
 
     int lastMatchEnd = 0;
     for (final match in matches) {
@@ -53,20 +62,22 @@ class EmojiText extends StatelessWidget {
         spans.add(
           TextSpan(
             text: text.substring(lastMatchEnd, match.start),
-            style: style,
+            style: effectiveStyle,
           ),
         );
       }
       spans.add(
         TextSpan(
           text: match.group(0),
-          style: style?.copyWith(fontFamily: FontFamily.twEmoji.value),
+          style: effectiveStyle.copyWith(fontFamily: FontFamily.emoji.value),
         ),
       );
       lastMatchEnd = match.end;
     }
     if (lastMatchEnd < text.length) {
-      spans.add(TextSpan(text: text.substring(lastMatchEnd), style: style));
+      spans.add(
+        TextSpan(text: text.substring(lastMatchEnd), style: effectiveStyle),
+      );
     }
 
     return spans;
@@ -74,11 +85,19 @@ class EmojiText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final effectiveStyle = DefaultTextStyle.of(context).style.merge(style);
+    final platform = Theme.of(context).platform;
+    final useBundledFlagFont =
+        !kIsWeb &&
+        (platform == TargetPlatform.linux ||
+            platform == TargetPlatform.windows);
     return RichText(
       textScaler: MediaQuery.of(context).textScaler,
       maxLines: maxLines,
       overflow: overflow ?? TextOverflow.clip,
-      text: TextSpan(children: _buildTextSpans(text)),
+      text: TextSpan(
+        children: _buildTextSpans(effectiveStyle, useBundledFlagFont),
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -458,14 +458,6 @@ packages:
       url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
-  emoji_regex:
-    dependency: "direct main"
-    description:
-      name: emoji_regex
-      sha256: "3a25dd4d16f98b6f76dc37cc9ae49b8511891ac4b87beac9443a1e9f4634b6c7"
-      url: "https://pub.flutter-io.cn"
-    source: hosted
-    version: "0.0.5"
   encrypt:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   ant_icons_plus: 2.0.1
   collection: 1.19.1
   flutter_emoji: 2.5.1
-  emoji_regex: 0.0.5
   dash_flags: 0.1.1
   country: 7.0.0
   sentry_flutter: 9.25.0

--- a/test/screens/widgets/text_test.dart
+++ b/test/screens/widgets/text_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:karing/screens/widgets/text.dart';
+
+void main() {
+  testWidgets('EmojiText applies the emoji font only to emoji spans', (
+    tester,
+  ) async {
+    const inheritedStyle = TextStyle(
+      fontFamily: 'TextFont',
+      fontSize: 16,
+      color: Colors.red,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.linux),
+        home: const DefaultTextStyle(
+          style: inheritedStyle,
+          child: EmojiText('🇫🇮 Helsinki'),
+        ),
+      ),
+    );
+
+    final richText = tester.widget<RichText>(
+      find.descendant(
+        of: find.byType(EmojiText),
+        matching: find.byType(RichText),
+      ),
+    );
+    final spans = (richText.text as TextSpan).children!.cast<TextSpan>();
+
+    expect(spans.map((span) => span.text), ['🇫🇮', ' Helsinki']);
+    expect(spans.first.style!.fontFamily, 'Emoji');
+    expect(spans.last.style!.fontFamily, 'TextFont');
+    expect(spans.first.style!.fontSize, 16);
+    expect(spans.last.style!.color, Colors.red);
+  });
+
+  testWidgets('EmojiText preserves an explicit text style', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.linux),
+        home: const EmojiText(
+          'Москва 🇷🇺 Extra',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+
+    final richText = tester.widget<RichText>(
+      find.descendant(
+        of: find.byType(EmojiText),
+        matching: find.byType(RichText),
+      ),
+    );
+    final spans = (richText.text as TextSpan).children!.cast<TextSpan>();
+
+    expect(spans.map((span) => span.text), ['Москва ', '🇷🇺', ' Extra']);
+    expect(spans[0].style!.fontFamily, isNot('Emoji'));
+    expect(spans[1].style!.fontFamily, 'Emoji');
+    expect(spans[2].style!.fontFamily, isNot('Emoji'));
+    expect(
+      spans.every((span) => span.style!.fontWeight == FontWeight.bold),
+      isTrue,
+    );
+  });
+
+  testWidgets('EmojiText leaves non-flag emoji to the normal font fallback', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.linux),
+        home: const EmojiText('Fast ⭐ server'),
+      ),
+    );
+
+    final richText = tester.widget<RichText>(
+      find.descendant(
+        of: find.byType(EmojiText),
+        matching: find.byType(RichText),
+      ),
+    );
+    final spans = (richText.text as TextSpan).children!.cast<TextSpan>();
+
+    expect(spans, hasLength(1));
+    expect(spans.single.text, 'Fast ⭐ server');
+    expect(spans.single.style!.fontFamily, isNot('Emoji'));
+  });
+
+  testWidgets('EmojiText preserves native flag rendering on Android', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.android),
+        home: const EmojiText('🇫🇮 Helsinki'),
+      ),
+    );
+
+    final richText = tester.widget<RichText>(
+      find.descendant(
+        of: find.byType(EmojiText),
+        matching: find.byType(RichText),
+      ),
+    );
+    final spans = (richText.text as TextSpan).children!.cast<TextSpan>();
+
+    expect(spans, hasLength(1));
+    expect(spans.single.text, '🇫🇮 Helsinki');
+    expect(spans.single.style!.fontFamily, isNot('Emoji'));
+  });
+}


### PR DESCRIPTION
## Summary

Fixes country flag rendering on Linux, where regional indicator sequences such as `🇩🇪` were displayed as letter codes (`DE`) instead of flags.

Closes #1593.

## Root cause

The bundled `Emoji.ttf` is a reduced Noto Color Emoji font containing only the 26 regional indicator characters used to compose country flags.

Flutter's normal font fallback on Linux does not always combine these characters into flags, even when a compatible system emoji font is installed.

## Difference from the previous fix

This implementation differs from the earlier Linux fix.

The previous approach assigned the bundled `Emoji` font to the entire server tag:

```dart
TextStyle(
  fontFamily: Platform.isWindows || Platform.isLinux ? 'Emoji' : null,
)
```

Because `Emoji.ttf` is a reduced font intended only for country flags, applying it to a complete mixed-content string could affect Cyrillic and Latin text rendering, font metrics and spacing.

This PR instead splits mixed strings into separate spans:

- country flag sequences use the bundled `Emoji.ttf`;
- Cyrillic and Latin text keep the regular UI font;
- other characters preserve their existing text style;
- non-flag emojis continue to use the platform's normal font fallback.

This avoids the text-rendering regressions that may have caused the previous fix to be reverted.

## Changes

- Fixed the existing `EmojiText` widget to use the registered `Emoji` font family.
- Detects country flags as pairs of regional indicator characters.
- Applies the bundled emoji font only to flag spans.
- Preserves inherited text styles for all non-flag spans.
- Uses the bundled flag font only on Linux and Windows.
- Preserves native flag rendering on Android, iOS, macOS, tvOS and Web.
- Applied `EmojiText` to screens that can display server tags or outbound chains:
  - server selection;
  - profiles;
  - home screen;
  - active connections;
  - network checks;
  - routing rule detection;
  - generic string selection and list screens.
- Removed the unused `emoji_regex` dependency.

## Testing

Tested with Flutter 3.47.1 and Dart 3.13.1.

Widget tests cover:

- applying `Emoji.ttf` only to country flag spans on Linux;
- preserving the regular text style for Cyrillic and Latin text;
- leaving non-flag emojis to the normal platform fallback;
- preserving native flag rendering on Android.

Result:

```text
All tests passed — 4/4
```

A standalone Linux UI preview was also built and visually verified with:

- country flags;
- Cyrillic and Latin text;
- regular non-flag emojis;
- outbound chain labels;
- mixed-content server names.

## Notes

A complete local Karing build was not possible because `vpn-service` and related components are private.

The flag-rendering widget was tested independently using a temporary dependency stub. The stub and standalone preview application are not included in this PR.