### PR TITLE
fix(linux): 解决 Linux 上 RPM 安装时 libcurl 符号版本依赖缺失的问题

### DIFF
--- a/linux/packaging/rpm/make_config.yaml
+++ b/linux/packaging/rpm/make_config.yaml
@@ -1,4 +1,5 @@
 display_name: Karing
+package_name: karing
 summary: Karing
 group: Applications/Internet
 vendor: KaringX
@@ -19,3 +20,8 @@ categories:
   - Applications/Internet
 
 startup_notify: true
+
+# Exclude Debian/Ubuntu-specific libcurl symbol versions (e.g. CURL_OPENSSL_4)
+# to prevent RPM dependency resolution failures on Fedora/RHEL/openSUSE
+spec_macros:
+  - '%global __requires_exclude ^libcurl\\.so\\.4\\(CURL_OPENSSL_.*\\).*$'


### PR DESCRIPTION
### 问题背景 (Background)

在 Fedora、RHEL、CentOS、openSUSE 等 RPM 发行版上使用 `dnf install` 安装 Karing RPM 包时，会发生如下依赖解析失败报错：

```text
Failed to resolve the transaction:
Problem: conflicting requests
  - nothing provides libcurl.so.4(CURL_OPENSSL_4)(64bit) needed by karing-1.2.24+2709-2709.x86_64 from @commandline
```

### 根因分析 (Root Cause)

1. 项目使用的 `sentry_flutter` 包含预编译的 `libsentry.so`，该库是在 Debian/Ubuntu 环境下编译的，链接了带 Debian 特有符号版本的 `libcurl.so.4(CURL_OPENSSL_4)`。
2. 在 Ubuntu/Debian 构建机上通过 `rpmbuild`（由 `flutter_distributor` 调用）生成 RPM 时，RPM 的自动依赖提取器检测到 `libsentry.so` 的符号版本，将 `libcurl.so.4(CURL_OPENSSL_4)(64bit)` 自动写入了 RPM 的 `Requires` 元数据中。
3. 然而，Fedora / RHEL / openSUSE 等发行版的 `libcurl` 遵循 upstream 标准，仅提供通用的 `libcurl.so.4()(64bit)`，并不导出 Debian 特有的 `CURL_OPENSSL_4` 符号版本。
4. 实际上在 Linux 运行时，动态链接器（`ld.so`）加载系统自带的 `libcurl.so.4` 即可正常绑定所有 curl 函数符号并正常运行；但由于 RPM 元数据中存在该符号版本约束，包管理器（`dnf` / `zypper`）会阻止安装。

### 变更内容 (Changes)

在 `linux/packaging/rpm/make_config.yaml` 中添加 `spec_macros` 配置：

```yaml
# Exclude Debian/Ubuntu-specific libcurl symbol versions (e.g. CURL_OPENSSL_4)
# to prevent RPM dependency resolution failures on Fedora/RHEL/openSUSE
spec_macros:
  - '%global __requires_exclude ^libcurl\\.so\\.4\\(CURL_OPENSSL_.*\\).*$'
```

- 该配置利用 RPM 官方标准宏 `%global __requires_exclude`，在 `rpmbuild` 生成 RPM 时过滤掉 Debian 特有的 `libcurl.so.4(CURL_OPENSSL_...)` 符号版本依赖；
- 保留通用的动态库依赖 `libcurl.so.4()(64bit)`，确保安装时系统仍会自动满足 `libcurl` 依赖；
- 补充了 `package_name: karing`，与 `linux/packaging/deb/make_config.yaml` 保持一致。

### 验证结果 (Verification)

1. **RPM 构建依赖对比**：
   - 修复前：`rpm -qp --requires` 包含 `libcurl.so.4()(64bit)` 和 `libcurl.so.4(CURL_OPENSSL_4)(64bit)`。
   - 修复后：Debian 符号版本依赖被成功过滤，仅保留通用库依赖 `libcurl.so.4()(64bit)`。
2. **Fedora 系统实际安装测试**：
   - 在 Fedora 44 系统上使用 `dnf install` 测试包含该改动的 RPM 包，依赖事务成功解析通过：
     ```text
     Updating and loading repositories:
     Repositories loaded.
     Package                 Arch   Version                  Repository          Size
     Upgrading:
      karing                 x86_64 0:1.2.24+2709-2709       @commandline   127.9 MiB
        replacing karing     x86_64 0:1.2.18+2102-2102       <unknown>      128.0 MiB

     Transaction Summary:
      Upgrading:          1 package
      Replacing:          1 package
     ```
   - 不再报 `nothing provides libcurl.so.4(CURL_OPENSSL_4)(64bit)` 错误。